### PR TITLE
update field types of ServiceRepositoryCreateInput for opslevel-go v2024

### DIFF
--- a/jq_repository_parser.go
+++ b/jq_repository_parser.go
@@ -17,8 +17,8 @@ type RepositoryDTO struct {
 func (r *RepositoryDTO) Convert() opslevel.ServiceRepositoryCreateInput {
 	return opslevel.ServiceRepositoryCreateInput{
 		Repository:    *opslevel.NewIdentifier(r.Repo),
-		BaseDirectory: r.Directory,
-		DisplayName:   r.Name,
+		BaseDirectory: opslevel.RefOf(r.Directory),
+		DisplayName:   opslevel.RefOf(r.Name),
 	}
 }
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Update fields to match `opslevel-go@v2024`. This should be merge after we cut a release of that.

🚨 we will need to run `task fix` to update `go.mod` and add that commit to this PR before merging

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
