### PR TITLE
update changie exec path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
             echo "Skip Changie..."
           else
             go install github.com/miniscruff/changie@latest
-            changie batch ${{ steps.version.outputs.RELEASE_VERSION }}
-            changie merge
+            $(go env GOPATH)/bin/changie batch ${{ steps.version.outputs.RELEASE_VERSION }}
+            $(go env GOPATH)/bin/changie merge
             git add .
             git commit -m "Cut Release '${{ steps.version.outputs.RELEASE_VERSION }}'"
             git push origin HEAD


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

`changie` not found in release workflow. Providing absolute path to changie binary

- [X] List your changes here
- [ ] Make a `changie` entry,  N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
