### PR TITLE
Use go embed to store files and write test cases

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,21 +30,21 @@ type ServiceRegistrationConfig struct {
 
 // ServiceRegistration represents the parsed json data from a ServiceRegistrationConfig
 type ServiceRegistration struct {
-	Aliases      []string                                `json:",omitempty"`
-	Description  string                                  `json:",omitempty"`
-	Framework    string                                  `json:",omitempty"`
-	Language     string                                  `json:",omitempty"`
-	Lifecycle    string                                  `json:",omitempty"`
-	Name         string                                  `json:",omitempty"`
-	Owner        string                                  `json:",omitempty"`
-	Product      string                                  `json:",omitempty"`
-	Properties   map[string]string                       `json:",omitempty"`
-	Repositories []opslevel.ServiceRepositoryCreateInput `json:",omitempty"` // This is a concrete class so fields are validated during `service preview`
-	System       string                                  `json:",omitempty"`
-	TagAssigns   []opslevel.TagInput                     `json:",omitempty"`
-	TagCreates   []opslevel.TagInput                     `json:",omitempty"`
-	Tier         string                                  `json:",omitempty"`
-	Tools        []opslevel.ToolCreateInput              `json:",omitempty"` // This is a concrete class so fields are validated during `service preview`
+	Aliases      []string                                `json:"aliases,omitempty"`
+	Description  string                                  `json:"description,omitempty"`
+	Framework    string                                  `json:"framework,omitempty"`
+	Language     string                                  `json:"language,omitempty"`
+	Lifecycle    string                                  `json:"lifecycle,omitempty"`
+	Name         string                                  `json:"name,omitempty"`
+	Owner        string                                  `json:"owner,omitempty"`
+	Product      string                                  `json:"product,omitempty"`
+	Properties   map[string]string                       `json:"properties,omitempty"`
+	Repositories []opslevel.ServiceRepositoryCreateInput `json:"repositories,omitempty"` // This is a concrete class so fields are validated during `service preview`
+	System       string                                  `json:"system,omitempty"`
+	TagAssigns   []opslevel.TagInput                     `json:"tagAssigns,omitempty"`
+	TagCreates   []opslevel.TagInput                     `json:"tagCreates,omitempty"`
+	Tier         string                                  `json:"tier,omitempty"`
+	Tools        []opslevel.ToolCreateInput              `json:"tools,omitempty"` // This is a concrete class so fields are validated during `service preview`
 }
 
 func NewServiceRegistrationConfig(data string) (*ServiceRegistrationConfig, error) {

--- a/config.go
+++ b/config.go
@@ -5,60 +5,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var SimpleConfig = `name: .metadata.name
-owner: .metadata.namespace
-aliases: # This are how we identify the services again during reconciliation - please make sure they are very unique
-  - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
-properties:
-  notfound: .metadata.annotations.notfound
-  notfound2: .metadata.annotations.notfound2
-  prop_bool: .metadata.annotations.prop_bool
-  prop_empty_object: .metadata.annotations.prop_empty_object
-  prop_empty_string: .metadata.annotations.prop_empty_string
-  prop_object: .metadata.annotations.prop_object
-  prop_string: .metadata.annotations.prop_string
-tags:
-  assign: # tag with the same key name but with a different value will be updated on the service
-    - '{"imported": "kubectl-opslevel"}'
-    - .metadata.labels
-  create: # tag with the same key name but with a different value with be added to the service
-    - '{"environment": .spec.template.metadata.labels.environment}'
-`
-
-var SampleConfig = `name: .metadata.name
-aliases: # This are how we identify the services again during reconciliation - please make sure they are very unique
-  - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
-  - '"\(.metadata.namespace)-\(.metadata.name)"'
-description: .metadata.annotations."opslevel.com/description"
-framework: .metadata.annotations."opslevel.com/framework"
-language: .metadata.annotations."opslevel.com/language"
-lifecycle: .metadata.annotations."opslevel.com/lifecycle"
-owner: .metadata.annotations."opslevel.com/owner"
-product: .metadata.annotations."opslevel.com/product"
-system: .metadata.annotations."opslevel.com/system"
-tier: .metadata.annotations."opslevel.com/tier"
-repositories: # attach repositories to the service using the opslevel repo alias - IE github.com:hashicorp/vault
-  - '{"name": "My Cool Repo", "directory": "", "repo": .metadata.annotations.repo} | if .repo then . else empty end'
-  # if just the alias is returned as a single string we'll build the name for you and set the directory to "/"
-  - .metadata.annotations.repo
-  # find annotations with format: opslevel.com/repo.<displayname>.<repo.subpath.dots.turned.to.forwardslash>: <opslevel repo alias>
-  - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
-tags:
-  assign: # tag with the same key name but with a different value will be updated on the service
-    - '{"imported": "kubectl-opslevel"}'
-    # find annotations with format: opslevel.com/tags.<key name>: <value>
-    - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tags"))) | map({(.key | split(".")[2]): .value})'
-    - .metadata.labels
-  create: # tag with the same key name but with a different value with be added to the service
-    - '{"environment": .spec.template.metadata.labels.environment}'
-tools:
-  - '{"category": "other", "environment": "production", "displayName": "my-cool-tool", "url": .metadata.annotations."example.com/my-cool-tool"} | if .url then . else empty end'
-  # find annotations with format: opslevel.com/tools.<category>.<displayname>: <url>
-  - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tools"))) | map({"category": .key | split(".")[2], "displayName": .key | split(".")[3], "url": .value})'
-  # OR find annotations with format: opslevel.com/tools.<category>.<environment>.<displayname>: <url>
-  # - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tools"))) | map({"category": .key | split(".")[2], "environment": .key | split(".")[3], "displayName": .key | split(".")[4], "url": .value})'
-`
-
 type TagRegistrationConfig struct {
 	Assign []string `json:"assign" yaml:"assign"` // JQ expressions that return a single string or a map[string]string
 	Create []string `json:"create" yaml:"create"` // JQ expressions that return a single string or a map[string]string

--- a/jq_service_parser_test.go
+++ b/jq_service_parser_test.go
@@ -1,323 +1,60 @@
 package opslevel_jq_parser_test
 
 import (
+	_ "embed"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"testing"
 
-	"github.com/opslevel/opslevel-go/v2024"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
 	"github.com/rocktavious/autopilot/v2023"
 )
 
-var k8sResource = `{
-    "apiVersion": "apps/v1",
-    "kind": "Deployment",
-    "metadata": {
-        "annotations": {
-			"deployment.kubernetes.io/revision": "243",
-			"kots.io/app-slug": "opslevel",
-			"opslevel.com/description": "this is a description",
-			"opslevel.com/framework": "rails",
-			"opslevel.com/language": "ruby",
-			"opslevel.com/lifecycle": "alpha",
-			"opslevel.com/owner": "velero",
-			"opslevel.com/product": "jklabs",
-			"opslevel.com/repo.terraform.clusters.dev.opslevel": "gitlab.com:opslevel/terraform",
-			"opslevel.com/system": "monolith",
-			"opslevel.com/tier": "tier_1",
-			"opslevel.com/tools.logs.my-ci": "https://circleci.com",
-			"opslevel.com/tools.logs.my-graphs": "https://datadog.com",
-			"opslevel.com/tools.logs.my-logs": "https://splunk.com",
-			"opslevel.com/tools.logs.my-logs": "https://splunk.com",
-			"opslevel.com/tools.logs.my-schedule": "https://pagerduty.com",
-			"opslevel.com/tools.logs.my-schedule": "https://pagerduty.com",
-			"prop_bool": true,
-			"prop_empty_object": {},
-			"prop_empty_string": "",
-			"prop_object": {"message": "hello world", "condition": true},
-			"prop_string": "hello world",
-			"repo": "github.com:hashicorp/vault"
-        },
-        "creationTimestamp": "2023-07-19T18:04:03Z",
-        "generation": 243,
-        "labels": {
-            "app.kubernetes.io/instance": "web",
-            "app.kubernetes.io/part-of": "opslevel",
-            "kots.io/app-slug": "opslevel",
-            "kots.io/backup": "velero"
-        },
-        "name": "web",
-        "namespace": "self-hosted",
-        "resourceVersion": "383293724",
-        "uid": "19d729de-f708-437c-8b65-10fa06d5dfd5"
-    },
-    "spec": {
-        "progressDeadlineSeconds": 600,
-        "replicas": 2,
-        "revisionHistoryLimit": 3,
-        "selector": {
-            "matchLabels": {
-                "app.kubernetes.io/instance": "web",
-                "app.kubernetes.io/part-of": "opslevel"
-            }
-        },
-        "strategy": {
-            "rollingUpdate": {
-                "maxSurge": "1",
-                "maxUnavailable": 0
-            },
-            "type": "RollingUpdate"
-        },
-        "template": {
-            "metadata": {
-                "annotations": {
-                    "kots.io/app-slug": "opslevel"
-                },
-                "creationTimestamp": null,
-                "labels": {
-                    "app.kubernetes.io/instance": "web",
-                    "app.kubernetes.io/part-of": "opslevel",
-					"environment": "dev",
-                    "collect-logs": "true"
-                }
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "args": [
-                            "bundle",
-                            "exec",
-                            "puma",
-                            "-C ./config/puma.rb"
-                        ],
-                        "env": [],
-                        "envFrom": [
-                            {
-                                "configMapRef": {
-                                    "name": "opslevel"
-                                }
-                            },
-                            {
-                                "secretRef": {
-                                    "name": "opslevel"
-                                }
-                            }
-                        ],
-                        "image": "opslevel/opslevel:main-240131e5",
-                        "imagePullPolicy": "Always",
-                        "lifecycle": {
-                            "preStop": {
-                                "exec": {
-                                    "command": [
-                                        "sleep",
-                                        "15"
-                                    ]
-                                }
-                            }
-                        },
-                        "livenessProbe": {
-                            "failureThreshold": 3,
-                            "initialDelaySeconds": 3,
-                            "periodSeconds": 20,
-                            "successThreshold": 1,
-                            "tcpSocket": {
-                                "port": "opslevel"
-                            },
-                            "timeoutSeconds": 1
-                        },
-                        "name": "web",
-                        "ports": [
-                            {
-                                "containerPort": 3000,
-                                "name": "opslevel",
-                                "protocol": "TCP"
-                            }
-                        ],
-                        "readinessProbe": {
-                            "failureThreshold": 3,
-                            "httpGet": {
-                                "path": "/api/ping",
-                                "port": "opslevel",
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 5,
-                            "periodSeconds": 10,
-                            "successThreshold": 2,
-                            "timeoutSeconds": 1
-                        },
-                        "resources": {
-                            "limits": {
-                                "cpu": "1",
-                                "memory": "1536Mi"
-                            },
-                            "requests": {
-                                "cpu": "500m",
-                                "memory": "500Mi"
-                            }
-                        },
-                        "terminationMessagePath": "/dev/termination-log",
-                        "terminationMessagePolicy": "File"
-                    }
-                ],
-                "dnsPolicy": "ClusterFirst",
-                "imagePullSecrets": [
-                    {
-                        "name": "opslevel-registry"
-                    }
-                ],
-                "initContainers": [
-                    {
-                        "args": [
-                            "bundle",
-                            "exec",
-                            "rake",
-                            "db:abort_if_pending_migrations"
-                        ],
-                        "envFrom": [
-                            {
-                                "configMapRef": {
-                                    "name": "opslevel"
-                                }
-                            },
-                            {
-                                "secretRef": {
-                                    "name": "opslevel"
-                                }
-                            }
-                        ],
-                        "image": "opslevel/opslevel:main-240131e5",
-                        "imagePullPolicy": "Always",
-                        "name": "migrations",
-                        "resources": {},
-                        "terminationMessagePath": "/dev/termination-log",
-                        "terminationMessagePolicy": "File"
-                    }
-                ],
-                "nodeSelector": {
-                    "kubernetes.io/os": "linux"
-                },
-                "restartPolicy": "Always",
-                "schedulerName": "default-scheduler",
-                "securityContext": {},
-                "terminationGracePeriodSeconds": 30,
-                "topologySpreadConstraints": [
-                    {
-                        "labelSelector": {
-                            "matchLabels": {
-                                "app.kubernetes.io/name": "web",
-                                "app.kubernetes.io/part-of": "opslevel"
-                            }
-                        },
-                        "maxSkew": 1,
-                        "topologyKey": "topology.kubernetes.io/zone",
-                        "whenUnsatisfiable": "ScheduleAnyway"
-                    }
-                ]
-            }
-        }
-    },
-    "status": {
-        "availableReplicas": 2,
-        "conditions": [
-            {
-                "lastTransitionTime": "2023-07-19T18:05:54Z",
-                "lastUpdateTime": "2023-07-19T18:05:54Z",
-                "message": "Deployment has minimum availability.",
-                "reason": "MinimumReplicasAvailable",
-                "status": "True",
-                "type": "Available"
-            },
-            {
-                "lastTransitionTime": "2023-08-31T09:00:52Z",
-                "lastUpdateTime": "2023-09-25T16:26:30Z",
-                "message": "ReplicaSet \"web-6fd48cb855\" has successfully progressed.",
-                "reason": "NewReplicaSetAvailable",
-                "status": "True",
-                "type": "Progressing"
-            }
-        ],
-        "observedGeneration": 243,
-        "readyReplicas": 2,
-        "replicas": 2,
-        "updatedReplicas": 2
-    }
-}
-`
+//go:embed testdata/deployment.json
+var k8sResource string
 
-func TestJQServiceParserSimpleConfig(t *testing.T) {
-	// Arrange
-	config, err := opslevel_jq_parser.NewServiceRegistrationConfig(opslevel_jq_parser.SimpleConfig)
-	if err != nil {
-		t.Error(err)
-	}
-	parser := opslevel_jq_parser.NewJQServiceParser(*config)
-	// Act
-	service, err := parser.Run(k8sResource)
-	if err != nil {
-		t.Error(err)
-	}
-	// Assert
-	autopilot.Equals(t, "web", service.Name)
-	autopilot.Equals(t, "self-hosted", service.Owner)
-	autopilot.Equals(t, "", service.Lifecycle)
-	autopilot.Equals(t, "", service.Tier)
-	autopilot.Equals(t, "", service.Product)
-	autopilot.Equals(t, "", service.Language)
-	autopilot.Equals(t, "", service.Framework)
-	// autopilot.Equals(t, "", service.System)
-	autopilot.Equals(t, 1, len(service.Aliases))
-	autopilot.Equals(t, "k8s:web-self-hosted", service.Aliases[0])
-	autopilot.Equals(t, 1, len(service.TagCreates))
-	autopilot.Equals(t, opslevel.TagInput{Key: "environment", Value: "dev"}, service.TagCreates[0])
-	autopilot.Equals(t, 5, len(service.TagAssigns))
-	autopilot.Equals(t, opslevel.TagInput{Key: "imported", Value: "kubectl-opslevel"}, service.TagAssigns[0])
-	autopilot.Equals(t, 0, len(service.Tools))
-	autopilot.Equals(t, 0, len(service.Repositories))
-	// property assignment
-	autopilot.Equals(t, 5, len(service.Properties))
-	autopilot.Equals(t, "true", service.Properties["prop_bool"])
-	autopilot.Equals(t, "{}", service.Properties["prop_empty_object"])
-	autopilot.Equals(t, "", service.Properties["prop_empty_string"])
-	autopilot.Equals(t, `{"message":"hello world","condition":true}`, service.Properties["prop_object"])
-	autopilot.Equals(t, "hello world", service.Properties["prop_string"])
-}
+//go:embed testdata/simple_config.yaml
+var simpleConfig string
 
-func TestJQServiceParserSampleConfig(t *testing.T) {
-	// Arrange
-	config, err := opslevel_jq_parser.NewServiceRegistrationConfig(opslevel_jq_parser.SampleConfig)
-	if err != nil {
-		t.Error(err)
+//go:embed testdata/sample_config.yaml
+var sampleConfig string
+
+//go:embed testdata/simple_expectation.json
+var simpleExpectation string
+
+//go:embed testdata/sample_expectation.json
+var sampleExpectation string
+
+func TestJQServiceParser(t *testing.T) {
+	type TestCase struct {
+		name               string
+		config             string
+		expectedServiceReg string
+	}
+	testCases := []TestCase{
+		{"using simple config", simpleConfig, simpleExpectation},
+		{"using sample config", sampleConfig, sampleExpectation},
 	}
 
-	parser := opslevel_jq_parser.NewJQServiceParser(*config)
-	// Act
-	service, err := parser.Run(k8sResource)
-	if err != nil {
-		t.Error(err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := opslevel_jq_parser.NewServiceRegistrationConfig(tc.config)
+			autopilot.Ok(t, err)
+			parser := opslevel_jq_parser.NewJQServiceParser(*config)
+			service, err := parser.Run(k8sResource)
+			autopilot.Ok(t, err)
+
+			var expectedService opslevel_jq_parser.ServiceRegistration
+			err = json.Unmarshal([]byte(tc.expectedServiceReg), &expectedService)
+			autopilot.Ok(t, err)
+			autopilot.Equals(t, expectedService, *service)
+		})
 	}
-	// Assert
-	autopilot.Equals(t, "web", service.Name)
-	autopilot.Equals(t, "this is a description", service.Description)
-	autopilot.Equals(t, "velero", service.Owner)
-	autopilot.Equals(t, "alpha", service.Lifecycle)
-	autopilot.Equals(t, "tier_1", service.Tier)
-	autopilot.Equals(t, "jklabs", service.Product)
-	autopilot.Equals(t, "ruby", service.Language)
-	autopilot.Equals(t, "rails", service.Framework)
-	// autopilot.Equals(t, "monolith", service.System)
-	autopilot.Equals(t, "k8s:web-self-hosted", service.Aliases[0])
-	autopilot.Equals(t, "self-hosted-web", service.Aliases[1])
-	autopilot.Equals(t, 1, len(service.TagCreates))
-	autopilot.Equals(t, opslevel.TagInput{Key: "environment", Value: "dev"}, service.TagCreates[0])
-	autopilot.Equals(t, 5, len(service.TagAssigns))
-	autopilot.Equals(t, opslevel.TagInput{Key: "imported", Value: "kubectl-opslevel"}, service.TagAssigns[0])
-	autopilot.Equals(t, 4, len(service.Tools))
-	autopilot.Equals(t, 3, len(service.Repositories))
 }
 
 func BenchmarkJQParser_New(b *testing.B) {
-	config, _ := opslevel_jq_parser.NewServiceRegistrationConfig(opslevel_jq_parser.SampleConfig)
+	config, _ := opslevel_jq_parser.NewServiceRegistrationConfig(sampleConfig)
 	parser := opslevel_jq_parser.NewJQServiceParser(*config)
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/jq_tags_parser.go
+++ b/jq_tags_parser.go
@@ -1,7 +1,9 @@
 package opslevel_jq_parser
 
 import (
+	"cmp"
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/opslevel/opslevel-go/v2024"
@@ -70,6 +72,10 @@ func (p *JQTagsParser) parse(programs []*JQFieldParser, data string) []opslevel.
 			}
 		}
 	}
+	// TODO: fix this hack to make the hashmap keys be consistent
+	slices.SortFunc(output, func(a, b opslevel.TagInput) int {
+		return cmp.Compare(a.Key+a.Value, b.Key+b.Value)
+	})
 	return output
 }
 

--- a/jq_tags_parser.go
+++ b/jq_tags_parser.go
@@ -1,9 +1,7 @@
 package opslevel_jq_parser
 
 import (
-	"cmp"
 	"encoding/json"
-	"slices"
 	"strings"
 
 	"github.com/opslevel/opslevel-go/v2024"
@@ -72,10 +70,6 @@ func (p *JQTagsParser) parse(programs []*JQFieldParser, data string) []opslevel.
 			}
 		}
 	}
-	// TODO: fix this hack to make the hashmap keys order be consistent (needed for testing.)
-	slices.SortFunc(output, func(a, b opslevel.TagInput) int {
-		return cmp.Compare(a.Key+a.Value, b.Key+b.Value)
-	})
 	return output
 }
 

--- a/jq_tags_parser.go
+++ b/jq_tags_parser.go
@@ -72,7 +72,7 @@ func (p *JQTagsParser) parse(programs []*JQFieldParser, data string) []opslevel.
 			}
 		}
 	}
-	// TODO: fix this hack to make the hashmap keys be consistent
+	// TODO: fix this hack to make the hashmap keys order be consistent (needed for testing.)
 	slices.SortFunc(output, func(a, b opslevel.TagInput) int {
 		return cmp.Compare(a.Key+a.Value, b.Key+b.Value)
 	})

--- a/testdata/deployment.json
+++ b/testdata/deployment.json
@@ -1,0 +1,236 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "243",
+            "kots.io/app-slug": "opslevel",
+            "opslevel.com/description": "this is a description",
+            "opslevel.com/framework": "rails",
+            "opslevel.com/language": "ruby",
+            "opslevel.com/lifecycle": "alpha",
+            "opslevel.com/owner": "velero",
+            "opslevel.com/product": "jklabs",
+            "opslevel.com/repo.terraform.clusters.dev.opslevel": "gitlab.com:opslevel/terraform",
+            "opslevel.com/system": "monolith",
+            "opslevel.com/tier": "tier_1",
+            "opslevel.com/tools.logs.my-ci": "https://circleci.com",
+            "opslevel.com/tools.logs.my-graphs": "https://datadog.com",
+            "opslevel.com/tools.logs.my-logs": "https://splunk.com",
+            "opslevel.com/tools.logs.my-logs": "https://splunk.com",
+            "opslevel.com/tools.logs.my-schedule": "https://pagerduty.com",
+            "opslevel.com/tools.logs.my-schedule": "https://pagerduty.com",
+            "prop_bool": true,
+            "prop_empty_object": {},
+            "prop_empty_string": "",
+            "prop_object": {
+                "message": "hello world",
+                "condition": true
+            },
+            "prop_string": "hello world",
+            "repo": "github.com:hashicorp/vault"
+        },
+        "creationTimestamp": "2023-07-19T18:04:03Z",
+        "generation": 243,
+        "labels": {
+            "app.kubernetes.io/instance": "web",
+            "app.kubernetes.io/part-of": "opslevel",
+            "kots.io/app-slug": "opslevel",
+            "kots.io/backup": "velero"
+        },
+        "name": "web",
+        "namespace": "self-hosted",
+        "resourceVersion": "383293724",
+        "uid": "19d729de-f708-437c-8b65-10fa06d5dfd5"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 2,
+        "revisionHistoryLimit": 3,
+        "selector": {
+            "matchLabels": {
+                "app.kubernetes.io/instance": "web",
+                "app.kubernetes.io/part-of": "opslevel"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "1",
+                "maxUnavailable": 0
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "annotations": {
+                    "kots.io/app-slug": "opslevel"
+                },
+                "creationTimestamp": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "web",
+                    "app.kubernetes.io/part-of": "opslevel",
+                    "environment": "dev",
+                    "collect-logs": "true"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "args": [
+                            "bundle",
+                            "exec",
+                            "puma",
+                            "-C ./config/puma.rb"
+                        ],
+                        "env": [],
+                        "envFrom": [
+                            {
+                                "configMapRef": {
+                                    "name": "opslevel"
+                                }
+                            },
+                            {
+                                "secretRef": {
+                                    "name": "opslevel"
+                                }
+                            }
+                        ],
+                        "image": "opslevel/opslevel:main-240131e5",
+                        "imagePullPolicy": "Always",
+                        "lifecycle": {
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "sleep",
+                                        "15"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "initialDelaySeconds": 3,
+                            "periodSeconds": 20,
+                            "successThreshold": 1,
+                            "tcpSocket": {
+                                "port": "opslevel"
+                            },
+                            "timeoutSeconds": 1
+                        },
+                        "name": "web",
+                        "ports": [
+                            {
+                                "containerPort": 3000,
+                                "name": "opslevel",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/api/ping",
+                                "port": "opslevel",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 10,
+                            "successThreshold": 2,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1536Mi"
+                            },
+                            "requests": {
+                                "cpu": "500m",
+                                "memory": "500Mi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "imagePullSecrets": [
+                    {
+                        "name": "opslevel-registry"
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "args": [
+                            "bundle",
+                            "exec",
+                            "rake",
+                            "db:abort_if_pending_migrations"
+                        ],
+                        "envFrom": [
+                            {
+                                "configMapRef": {
+                                    "name": "opslevel"
+                                }
+                            },
+                            {
+                                "secretRef": {
+                                    "name": "opslevel"
+                                }
+                            }
+                        ],
+                        "image": "opslevel/opslevel:main-240131e5",
+                        "imagePullPolicy": "Always",
+                        "name": "migrations",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30,
+                "topologySpreadConstraints": [
+                    {
+                        "labelSelector": {
+                            "matchLabels": {
+                                "app.kubernetes.io/name": "web",
+                                "app.kubernetes.io/part-of": "opslevel"
+                            }
+                        },
+                        "maxSkew": 1,
+                        "topologyKey": "topology.kubernetes.io/zone",
+                        "whenUnsatisfiable": "ScheduleAnyway"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 2,
+        "conditions": [
+            {
+                "lastTransitionTime": "2023-07-19T18:05:54Z",
+                "lastUpdateTime": "2023-07-19T18:05:54Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastTransitionTime": "2023-08-31T09:00:52Z",
+                "lastUpdateTime": "2023-09-25T16:26:30Z",
+                "message": "ReplicaSet \"web-6fd48cb855\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            }
+        ],
+        "observedGeneration": 243,
+        "readyReplicas": 2,
+        "replicas": 2,
+        "updatedReplicas": 2
+    }
+}

--- a/testdata/sample_config.yaml
+++ b/testdata/sample_config.yaml
@@ -1,0 +1,26 @@
+name: .metadata.name
+aliases:
+  - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
+  - '"\(.metadata.namespace)-\(.metadata.name)"'
+description: .metadata.annotations."opslevel.com/description"
+framework: .metadata.annotations."opslevel.com/framework"
+language: .metadata.annotations."opslevel.com/language"
+lifecycle: .metadata.annotations."opslevel.com/lifecycle"
+owner: .metadata.annotations."opslevel.com/owner"
+product: .metadata.annotations."opslevel.com/product"
+system: .metadata.annotations."opslevel.com/system"
+tier: .metadata.annotations."opslevel.com/tier"
+repositories:
+  - '{"name": "My Cool Repo", "directory": "", "repo": .metadata.annotations.repo} | if .repo then . else empty end'
+  - .metadata.annotations.repo
+  - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
+tags:
+  assign:
+    - '{"imported": "kubectl-opslevel"}'
+    - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tags"))) | map({(.key | split(".")[2]): .value})'
+    - .metadata.labels
+  create:
+    - '{"environment": .spec.template.metadata.labels.environment}'
+tools:
+  - '{"category": "other", "environment": "production", "displayName": "my-cool-tool", "url": .metadata.annotations."example.com/my-cool-tool"} | if .url then . else empty end'
+  - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tools"))) | map({"category": .key | split(".")[2], "displayName": .key | split(".")[3], "url": .value})'

--- a/testdata/sample_expectation.json
+++ b/testdata/sample_expectation.json
@@ -10,6 +10,7 @@
     "name": "web",
     "owner": "velero",
     "product": "jklabs",
+    "properties": {},
     "repositories": [
         {
             "service": null,
@@ -37,16 +38,16 @@
     "system": "monolith",
     "tagAssigns": [
         {
-            "key": "imported",
-            "value": "kubectl-opslevel"
-        },
-        {
             "key": "app.kubernetes.io/instance",
             "value": "web"
         },
         {
             "key": "app.kubernetes.io/part-of",
             "value": "opslevel"
+        },
+        {
+            "key": "imported",
+            "value": "kubectl-opslevel"
         },
         {
             "key": "kots.io/app-slug",

--- a/testdata/sample_expectation.json
+++ b/testdata/sample_expectation.json
@@ -1,0 +1,89 @@
+{
+    "aliases": [
+        "k8s:web-self-hosted",
+        "self-hosted-web"
+    ],
+    "description": "this is a description",
+    "framework": "rails",
+    "language": "ruby",
+    "lifecycle": "alpha",
+    "name": "web",
+    "owner": "velero",
+    "product": "jklabs",
+    "repositories": [
+        {
+            "service": null,
+            "repository": {
+                "alias": "github.com:hashicorp/vault"
+            },
+            "baseDirectory": "",
+            "displayName": "My Cool Repo"
+        },
+        {
+            "service": null,
+            "repository": {
+                "alias": "github.com:hashicorp/vault"
+            }
+        },
+        {
+            "service": null,
+            "repository": {
+                "alias": "gitlab.com:opslevel/terraform"
+            },
+            "baseDirectory": "clusters/dev/opslevel",
+            "displayName": "terraform"
+        }
+    ],
+    "system": "monolith",
+    "tagAssigns": [
+        {
+            "key": "imported",
+            "value": "kubectl-opslevel"
+        },
+        {
+            "key": "app.kubernetes.io/instance",
+            "value": "web"
+        },
+        {
+            "key": "app.kubernetes.io/part-of",
+            "value": "opslevel"
+        },
+        {
+            "key": "kots.io/app-slug",
+            "value": "opslevel"
+        },
+        {
+            "key": "kots.io/backup",
+            "value": "velero"
+        }
+    ],
+    "tagCreates": [
+        {
+            "key": "environment",
+            "value": "dev"
+        }
+    ],
+    "tier": "tier_1",
+    "tools": [
+        {
+            "category": "logs",
+            "displayName": "my-ci",
+            "url": "https://circleci.com"
+        },
+        {
+            "category": "logs",
+            "displayName": "my-graphs",
+            "url": "https://datadog.com"
+        },
+        {
+            "category": "logs",
+            "displayName": "my-logs",
+            "url": "https://splunk.com"
+        },
+        {
+            "category": "logs",
+            "displayName": "my-schedule",
+            "url": "https://pagerduty.com"
+        }
+    ]
+}

--- a/testdata/simple_config.yaml
+++ b/testdata/simple_config.yaml
@@ -1,0 +1,18 @@
+name: .metadata.name
+owner: .metadata.namespace
+aliases:
+  - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
+properties:
+  notfound: .metadata.annotations.notfound
+  notfound2: .metadata.annotations.notfound2
+  prop_bool: .metadata.annotations.prop_bool
+  prop_empty_object: .metadata.annotations.prop_empty_object
+  prop_empty_string: .metadata.annotations.prop_empty_string
+  prop_object: .metadata.annotations.prop_object
+  prop_string: .metadata.annotations.prop_string
+tags:
+  assign:
+    - '{"imported": "kubectl-opslevel"}'
+    - .metadata.labels
+  create:
+    - '{"environment": .spec.template.metadata.labels.environment}'

--- a/testdata/simple_expectation.json
+++ b/testdata/simple_expectation.json
@@ -1,0 +1,42 @@
+{
+    "aliases": [
+        "k8s:web-self-hosted"
+    ],
+    "name": "web",
+    "owner": "self-hosted",
+    "properties": {
+        "prop_bool": "true",
+        "prop_empty_object": "{}",
+        "prop_empty_string": "",
+        "prop_object": "{\"message\":\"hello world\",\"condition\":true}",
+        "prop_string": "hello world"
+    },
+    "tagAssigns": [
+        {
+            "key": "imported",
+            "value": "kubectl-opslevel"
+        },
+        {
+            "key": "app.kubernetes.io/instance",
+            "value": "web"
+        },
+        {
+            "key": "app.kubernetes.io/part-of",
+            "value": "opslevel"
+        },
+        {
+            "key": "kots.io/app-slug",
+            "value": "opslevel"
+        },
+        {
+            "key": "kots.io/backup",
+            "value": "velero"
+        }
+    ],
+    "tagCreates": [
+        {
+            "key": "environment",
+            "value": "dev"
+        }
+    ]
+}

--- a/testdata/simple_expectation.json
+++ b/testdata/simple_expectation.json
@@ -13,7 +13,6 @@
     },
     "repositories": [],
     "tagAssigns": [
-
         {
             "key": "app.kubernetes.io/instance",
             "value": "web"

--- a/testdata/simple_expectation.json
+++ b/testdata/simple_expectation.json
@@ -11,11 +11,9 @@
         "prop_object": "{\"message\":\"hello world\",\"condition\":true}",
         "prop_string": "hello world"
     },
+    "repositories": [],
     "tagAssigns": [
-        {
-            "key": "imported",
-            "value": "kubectl-opslevel"
-        },
+
         {
             "key": "app.kubernetes.io/instance",
             "value": "web"
@@ -23,6 +21,10 @@
         {
             "key": "app.kubernetes.io/part-of",
             "value": "opslevel"
+        },
+        {
+            "key": "imported",
+            "value": "kubectl-opslevel"
         },
         {
             "key": "kots.io/app-slug",
@@ -38,5 +40,6 @@
             "key": "environment",
             "value": "dev"
         }
-    ]
+    ],
+    "tools": []
 }


### PR DESCRIPTION
## Issues

Part of - https://github.com/OpsLevel/team-platform/issues/278

## Changelog

- [x] Use `//go:embed` to store config, test files in the testdata/ directory
- [x] Re-write tests to use these embedded values (this is more accurate than the previous tests because every single element in a list is examined, not just the length of a list.)
  - [x] Generated the *_expectation.json files by outputting the marshal output from the main branch before testing anything
- [x] Fix tests that are failing
  - [x] Add `repositories: []` and `tools: []` in *_expecatation.json - this is necessary because otherwise the expectation will contain `nil` for those 2 fiels whereas in the actual application those 2 are always initialized to an array.
  - [x] Add a sort function to when tags keys are extracted from a hashmap - this approach is bad but this will be fixed in a later PR. 