### PR TITLE
remove property empty string test - no longer valid

### DIFF
--- a/testdata/simple_config.yaml
+++ b/testdata/simple_config.yaml
@@ -7,7 +7,6 @@ properties:
   notfound2: .metadata.annotations.notfound2
   prop_bool: .metadata.annotations.prop_bool
   prop_empty_object: .metadata.annotations.prop_empty_object
-  prop_empty_string: .metadata.annotations.prop_empty_string
   prop_object: .metadata.annotations.prop_object
   prop_string: .metadata.annotations.prop_string
 tags:

--- a/testdata/simple_expectation.json
+++ b/testdata/simple_expectation.json
@@ -7,7 +7,6 @@
     "properties": {
         "prop_bool": "true",
         "prop_empty_object": "{}",
-        "prop_empty_string": "",
         "prop_object": "{\"message\":\"hello world\",\"condition\":true}",
         "prop_string": "hello world"
     },


### PR DESCRIPTION
## Issues

Follow-up to https://github.com/OpsLevel/opslevel-jq-parser/pull/38

## Changelog

- [ ] Remove property test since `""` is no longer a valid expression result.

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
