### PR TITLE
have parsed jq expr return blank string instead of null

### DIFF
--- a/.changes/unreleased/Bugfix-20240312-131037.yaml
+++ b/.changes/unreleased/Bugfix-20240312-131037.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: have parsed jq expr return blank string instead of null
+time: 2024-03-12T13:10:37.776529-05:00

--- a/.changes/unreleased/Feature-20240311-155859.yaml
+++ b/.changes/unreleased/Feature-20240311-155859.yaml
@@ -1,3 +1,0 @@
-kind: Feature
-body: append empty check to jq expression
-time: 2024-03-11T15:58:59.217393-05:00

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -53,7 +53,7 @@ tasks:
           echo "Copying {{.ROOT_DIR}}/{{.CLI_ARGS}} to {{.LOCAL_DIR}}/{{.LOCAL_CONFIG_YAML}} for local testing..."
           cp {{.ROOT_DIR}}/{{.CLI_ARGS}} {{.LOCAL_CONFIG_YAML}}
         fi
-      - go run parse.go {{.LOCAL_CONFIG_YAML}}
+      - go run parse.go
 
   setup:
     desc: Setup linter, formatter, etc. for local testing and CI

--- a/jq_dict_parser.go
+++ b/jq_dict_parser.go
@@ -16,7 +16,6 @@ func NewJQDictParser(dict map[string]string) map[string]JQFieldParser {
 	}
 	jq := libjq_go.Jq()
 	for key, expression := range dict {
-		expression = appendEmptyExpr(expression)
 		prg, err := jq.Program(expression).Precompile()
 		if err != nil {
 			panic(fmt.Sprintf("unable to compile jq dict: %s", dict))

--- a/jq_field_parser.go
+++ b/jq_field_parser.go
@@ -7,19 +7,11 @@ import (
 	"github.com/flant/libjq-go/pkg/jq"
 )
 
-func appendEmptyExpr(expression string) string {
-	if expression == "" {
-		return "empty"
-	}
-	return expression + " // empty"
-}
-
 type JQFieldParser struct {
 	program *jq.JqProgram
 }
 
 func NewJQFieldParser(expression string) *JQFieldParser {
-	expression = appendEmptyExpr(expression)
 	prg, err := libjq_go.Jq().Program(expression).Precompile()
 	if err != nil {
 		panic(fmt.Sprintf("unable to compile jq expression:  %s", expression))

--- a/jq_field_parser.go
+++ b/jq_field_parser.go
@@ -12,6 +12,9 @@ type JQFieldParser struct {
 }
 
 func NewJQFieldParser(expression string) *JQFieldParser {
+	if expression == "" {
+		expression = "empty"
+	}
 	prg, err := libjq_go.Jq().Program(expression).Precompile()
 	if err != nil {
 		panic(fmt.Sprintf("unable to compile jq expression:  %s", expression))

--- a/jq_field_parser.go
+++ b/jq_field_parser.go
@@ -30,5 +30,12 @@ func NewJQFieldParser(expression string) *JQFieldParser {
 }
 
 func (p *JQFieldParser) Run(data string) (string, error) {
-	return p.program.RunRaw(data)
+	parsedData, err := p.program.RunRaw(data)
+	if err != nil {
+		return "", err
+	}
+	if parsedData == "null" {
+		return "", nil
+	}
+	return parsedData, nil
 }


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

`p.program.RunRaw(data)` returns a string. If the result of the underlying jq parser is `null` then the returned value from `RunRaw()` becomes `"null"`. Convert this to a blank string instead

- [X] List your changes here
- [ ] Make a `changie` entry, N/A

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
