### PR TITLE
stop using `make()` with capacity arg

### DIFF
--- a/jq_array_parser.go
+++ b/jq_array_parser.go
@@ -24,7 +24,7 @@ func NewJQArrayParser(expressions []string) *JQArrayParser {
 }
 
 func (p *JQArrayParser) Run(data string) ([]string, error) {
-	output := make([]string, 0, len(p.programs))
+	output := make([]string, 0)
 	for _, program := range p.programs {
 		response, err := program.Run(data)
 		if err != nil {

--- a/jq_tags_parser.go
+++ b/jq_tags_parser.go
@@ -28,7 +28,7 @@ func NewJQTagsParser(cfg TagRegistrationConfig) *JQTagsParser {
 }
 
 func (p *JQTagsParser) parse(programs []*JQFieldParser, data string) []opslevel.TagInput {
-	output := make([]opslevel.TagInput, 0, len(programs))
+	output := make([]opslevel.TagInput, 0)
 	for _, program := range programs {
 		response, err := program.Run(data)
 		if err != nil {

--- a/jq_tools_parser.go
+++ b/jq_tools_parser.go
@@ -23,7 +23,7 @@ func NewJQToolsParser(expressions []string) *JQToolsParser {
 }
 
 func (p *JQToolsParser) Run(data string) ([]opslevel.ToolCreateInput, error) {
-	output := make([]opslevel.ToolCreateInput, 0, len(p.programs))
+	output := make([]opslevel.ToolCreateInput, 0)
 	for _, program := range p.programs {
 		response, err := program.Run(data)
 		if err != nil {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/278

## Changelog

- [x] STOP specifying the capacity argument in `make()` because it's not determined that N expressions will result in N results when we are dealing with arrays that could have multiple results per expression.

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
