### PR TITLE
ensure repositories have repo before calling serviceRepositoryCreate

### DIFF
--- a/jq_repository_parser.go
+++ b/jq_repository_parser.go
@@ -37,7 +37,7 @@ func NewJQRepositoryParser(expressions []string) *JQRepositoryParser {
 }
 
 func (p *JQRepositoryParser) Run(data string) ([]opslevel.ServiceRepositoryCreateInput, error) {
-	output := make([]opslevel.ServiceRepositoryCreateInput, 0, len(p.programs))
+	output := []opslevel.ServiceRepositoryCreateInput{}
 	for _, program := range p.programs {
 		response, err := program.Run(data)
 		// log.Warn().Msgf("expression: %s\nresponse: %s", program.program.Program, response)
@@ -55,7 +55,9 @@ func (p *JQRepositoryParser) Run(data string) ([]opslevel.ServiceRepositoryCreat
 			var repos []RepositoryDTO
 			if err := json.Unmarshal([]byte(response), &repos); err == nil {
 				for _, repo := range repos {
-					output = append(output, repo.Convert())
+					if repo.Repo != "" {
+						output = append(output, repo.Convert())
+					}
 				}
 			} else {
 				// Try as []string
@@ -73,7 +75,9 @@ func (p *JQRepositoryParser) Run(data string) ([]opslevel.ServiceRepositoryCreat
 				log.Warn().Err(err).Msgf("unable to marshal repo expression: %s\n%s", program.program.Program, response)
 				continue
 			}
-			output = append(output, repo.Convert())
+			if repo.Repo != "" {
+				output = append(output, repo.Convert())
+			}
 		} else {
 			output = append(output, opslevel.ServiceRepositoryCreateInput{Repository: *opslevel.NewIdentifier(response)})
 		}

--- a/jq_repository_parser.go
+++ b/jq_repository_parser.go
@@ -37,7 +37,7 @@ func NewJQRepositoryParser(expressions []string) *JQRepositoryParser {
 }
 
 func (p *JQRepositoryParser) Run(data string) ([]opslevel.ServiceRepositoryCreateInput, error) {
-	output := []opslevel.ServiceRepositoryCreateInput{}
+	output := make([]opslevel.ServiceRepositoryCreateInput, 0)
 	for _, program := range p.programs {
 		response, err := program.Run(data)
 		// log.Warn().Msgf("expression: %s\nresponse: %s", program.program.Program, response)

--- a/testdata/sample_config.yaml
+++ b/testdata/sample_config.yaml
@@ -14,6 +14,7 @@ repositories:
   - '{"name": "My Cool Repo", "directory": "", "repo": .metadata.annotations.repo} | if .repo then . else empty end'
   - .metadata.annotations.repo
   - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
+  - '{"name": "Not a Valid Repo should be ignored", "directory": ""}'
 tags:
   assign:
     - '{"imported": "kubectl-opslevel"}'


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Skip creating a `ServiceRepositoryCreateInput` if `ServiceRepositoryCreateInput.Repository` would be blank.
Added invalid `- '{"name": "Not a Valid Repo should be ignored", "directory": ""}'` to array of repositories in `testdata/sample_config.yaml` and it is ignored


- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
